### PR TITLE
Remove binary audio from repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+piper_voices/
+
+audiobooks/*.wav

--- a/audiobooks/README.md
+++ b/audiobooks/README.md
@@ -1,0 +1,1 @@
+This directory holds generated audiobook files.

--- a/stories/the_fox_and_the_grapes.txt
+++ b/stories/the_fox_and_the_grapes.txt
@@ -1,0 +1,4 @@
+Once upon a time, a hungry fox saw a bunch of grapes hanging from a vine.
+He jumped and jumped but could not reach them.
+Tired of trying, he walked away saying, "Those grapes were probably sour anyway."
+And so he learned to live without them.


### PR DESCRIPTION
## Summary
- remove generated WAV file from version control
- ignore future audiobooks
- keep empty audiobooks folder with README

## Testing
- `python - <<'PY'
from tts_utils import piper_text_to_speech
from pathlib import Path
text = open('stories/the_fox_and_the_grapes.txt').read()
output_file = 'audiobooks/the_fox_and_the_grapes.wav'
piper_text_to_speech(text, output_file)
print('Generated', output_file, Path(output_file).exists())
PY`


------
https://chatgpt.com/codex/tasks/task_e_683ffcae6cf08328a9d15bf007e471e1